### PR TITLE
fix:(图片处理的test): 给imageTool.test.js的颜色正则，rabg,hsla的a添加1.0校验规则

### DIFF
--- a/test/imageTool.test.js
+++ b/test/imageTool.test.js
@@ -2,9 +2,9 @@ import { hex2rgba, rgba2obj,genRandomColor } from '../src/index';
 
 const reg16 = /^#?([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$/
 const  regRgb = /rgb\((\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]),(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]),(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\)/;
-const  regRgba = /rgba\((\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]),(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]),(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]),(0.\d+|0|1)\)/;
+const  regRgba = /rgba\((\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]),(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]),(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]),(0.\d+|0|1)|(1.0)\)/;
 const  regHsl = /hsl\(\s*(\d+)\s*,\s*(\d+(?:\.\d+)?%)\s*,\s*(\d+(?:\.\d+)?%)\)/;
-const  regHsla = /hsla\(\s*(\d+)\s*,\s*(\d+(?:\.\d+)?%)\s*,\s*(\d+(?:\.\d+)?%),(0.\d+|0|1)\)/;
+const  regHsla = /hsla\(\s*(\d+)\s*,\s*(\d+(?:\.\d+)?%)\s*,\s*(\d+(?:\.\d+)?%),(0.\d+|0|1)|(1.0)\)/;
 describe('图片处理函数相关测试', () => {
   test('hex 色值转 rgba', async () => {
     const transformRgba = hex2rgba('#fff'),


### PR DESCRIPTION
fix:(图片处理的test): 给imageTool.test.js的颜色正则，rabg,hsla的a添加1.0校验规则