### PR TITLE
fix: hyphenate |  transformTree  函数优化

### DIFF
--- a/src/hyphenate/__tests__/index.test.ts
+++ b/src/hyphenate/__tests__/index.test.ts
@@ -5,5 +5,7 @@ describe('hyphenate', () => {
     const s = 'AaBb1Cc2Dd_Ee.Ff';
     expect(hyphenate(s)).toBe('aa-bb1-cc2-dd_-ee.ff');
     expect(hyphenate(s, '_')).toBe('aa_bb1_cc2_dd__ee.ff');
+    const w = 'getDataFromDB';
+    expect(hyphenate(w, '_')).toBe('get_data_from_db');
   });
 });

--- a/src/hyphenate/index.ts
+++ b/src/hyphenate/index.ts
@@ -4,7 +4,7 @@
  * @returns
  */
 function hyphenate(str: string, flag = '-') {
-  const hyphenateRE = /\B([A-Z])/g;
-  return str.replace(hyphenateRE, `${flag}$1`).toLowerCase();
+  const hyphenateReg = /([a-z0-9_])([A-Z])|([A-Z])([A-Z][a-z])/g;
+  return str.replace(hyphenateReg, `$1$3${flag}$2$4`).toLowerCase();
 }
 export default hyphenate;

--- a/src/transformTree/__tests__/index.test.ts
+++ b/src/transformTree/__tests__/index.test.ts
@@ -55,4 +55,130 @@ describe('transformTree', () => {
     ];
     expect(tree).toEqual(expectTree);
   });
+  test('将无根节点的扁平数组转换成树结构', () => {
+    const list = [
+      {
+        name: '主页',
+        id: '1',
+        parentId: '0',
+      },
+      {
+        name: '学习天地',
+        id: '2',
+        parentId: '0',
+      },
+      {
+        name: '前端',
+        id: '3',
+        parentId: '2',
+      },
+      {
+        name: '后端',
+        id: '4',
+        parentId: '2',
+      },
+      {
+        name: 'JavaScript',
+        id: '5',
+        parentId: '3',
+      },
+      {
+        name: 'Vue',
+        id: '6',
+        parentId: '5',
+      },
+      {
+        name: 'React',
+        id: '7',
+        parentId: '5',
+      },
+      {
+        name: 'Node',
+        id: '8',
+        parentId: '4',
+      },
+      {
+        name: 'Java',
+        id: '9',
+        parentId: '4',
+      },
+      {
+        name: '关于我们',
+        id: '10',
+        parentId: '0',
+      },
+    ];
+    const expectArr = [
+      {
+        name: '主页',
+        id: '1',
+        parentId: '0',
+        children: [],
+      },
+      {
+        name: '学习天地',
+        id: '2',
+        parentId: '0',
+        children: [
+          {
+            name: '前端',
+            id: '3',
+            parentId: '2',
+            children: [
+              {
+                name: 'JavaScript',
+                id: '5',
+                parentId: '3',
+                children: [
+                  {
+                    name: 'Vue',
+                    id: '6',
+                    parentId: '5',
+                    children: [],
+                  },
+                  {
+                    name: 'React',
+                    id: '7',
+                    parentId: '5',
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: '后端',
+            id: '4',
+            parentId: '2',
+            children: [
+              {
+                name: 'Node',
+                id: '8',
+                parentId: '4',
+                children: [],
+              },
+              {
+                name: 'Java',
+                id: '9',
+                parentId: '4',
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: '关于我们',
+        id: '10',
+        parentId: '0',
+        children: [],
+      },
+    ];
+    const arr = transformTree(list, {
+      keyField: 'id',
+      childField: 'children',
+      parentField: 'parentId',
+    });
+    expect(arr).toEqual(expectArr);
+  });
 });

--- a/src/transformTree/index.ts
+++ b/src/transformTree/index.ts
@@ -4,46 +4,63 @@
  * @param options 树解析map
  * @returns
  */
-function transformTree(
-  list: any[] = [],
-  options = {
-    keyField: 'id',
-    childField: 'children',
-    parentField: 'pid',
-  },
-) {
-  const { keyField, childField, parentField } = options;
-
-  const tree = [];
+const defaultOptions = {
+  keyField: 'id',
+  childField: 'children',
+  parentField: 'pid',
+  emptyIsNull: false,
+};
+interface ITransformTreeOptions {
+  keyField?: string;
+  childField?: string;
+  parentField?: string;
+  emptyIsNull?: boolean; // 如果子值为空是否设置为null, 默认true, 默认子值为 null, 如果为false, 空子值为 []
+}
+/**
+ * 将扁平数组转换成树结构
+ * @param list
+ * @param options
+ * @returns
+ */
+function transformTree(list: any[] = [], options: ITransformTreeOptions = {}) {
+  const { keyField, childField, parentField, emptyIsNull } = {
+    ...defaultOptions,
+    ...options,
+  };
+  let tree: any[] = [];
   const record: any = {};
-
-  for (let i = 0, len = list.length; i < len; i++) {
-    const item = list[i];
-    const id = item[keyField];
-
-    if (!id) {
-      continue;
+  list.forEach((item) => {
+    if (!record[item[keyField]]) {
+      record[item[keyField]] = {
+        ...item,
+        [childField]: emptyIsNull ? null : [],
+      };
     }
 
-    if (record[id]) {
-      item[childField] = record[id];
-    } else {
-      item[childField] = record[id] = [];
-    }
-
-    if (item[parentField]) {
-      const parentId = item[parentField];
-
-      if (!record[parentId]) {
-        record[parentId] = [];
+    if (record[item[parentField]]) {
+      if (!record[item[parentField]][childField]) {
+        record[item[parentField]][childField] = [];
       }
-
-      record[parentId].push(item);
+      record[item[parentField]][childField].push(record[item[keyField]]);
     } else {
-      tree.push(item);
+      if (item[parentField]) {
+        record[item[parentField]] = {
+          [keyField]: item[parentField],
+          [childField]: [record[item[keyField]]],
+        };
+      }
     }
-  }
+  });
 
+  Object.keys(record).forEach((recordKey) => {
+    if (!record[recordKey][parentField]) {
+      tree.push(record[recordKey]);
+    }
+  });
+
+  if (tree.length === 1 && tree[0][parentField] === undefined) {
+    tree = tree?.[0]?.[childField] || [];
+  }
   return tree;
 }
 


### PR DESCRIPTION
对 `hyphenate` 做了点优化, 针对连续大写专有名词
```js
// 优化前:
console.log(hyphenate('getDataFromDB', '_')) // output: get_data_from_d_b
// 优化后:
console.log(hyphenate('getDataFromDB', '_')) // output: get_data_from_db
```